### PR TITLE
fix some bugs

### DIFF
--- a/contracts/Hamming.sol
+++ b/contracts/Hamming.sol
@@ -27,6 +27,23 @@ library Hamming {
         return distance;
     }
 
+    function compareHamming(
+        bytes memory a,
+        bytes memory b,
+        uint threshold
+    ) internal pure returns (bool) {
+        if (a.length == b.length && a.length % 8 == 0) {
+            for (uint start = 0; start < a.length; start += 8) {
+                uint distance = hamming(a, b, start, start + 8);
+                if (distance >= threshold) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     function slice(
         bytes memory _bytes,
         uint256 _start,

--- a/contracts/Node.sol
+++ b/contracts/Node.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./QOS.sol";
+import "./Random.sol";
 import "./NetworkStats.sol";
 
 
@@ -16,6 +17,7 @@ contract Node is Ownable {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
+    using Random for Random.Generator;
 
     uint256 private maxNodesAllowed = 100000;
     uint256 private requiredStakeAmount = 400 * 10 ** 18;
@@ -62,6 +64,8 @@ contract Node is Ownable {
     mapping(bytes32 => uint) private _gpuIDGroupScores;
 
     address private taskContractAddress;
+
+    Random.Generator private generator;
 
     constructor(IERC20 tokenInstance, QOS qosInstance, NetworkStats netStatsInstance) {
         cnxToken = tokenInstance;
@@ -393,6 +397,49 @@ contract Node is Ownable {
             scores[i] = score;
         }
         return (nodes, scores);
+    }
+
+    function randomSelectNodes(
+        uint k,
+        uint vramLimit,
+        bool useSameGPU,
+        bytes32 seed
+    ) external returns (address[] memory) {
+        require(k > 0, "select nodes count cannot be zero");
+
+        generator.manualSeed(seed);
+        address nodeAddress;
+        address[] memory res = new address[](k);
+
+        if (useSameGPU) {
+            (bytes32[] memory gpuIDs, uint[] memory idScores) = filterGPUID(vramLimit, k);
+            uint index = generator.multinomial(idScores, 0, idScores.length);
+            bytes32 gpuID = gpuIDs[index];
+            for (uint i = 0; i < k; i++) {
+                (address[] memory nodes, uint[] memory scores) = filterNodesByGPUID(gpuID);
+                uint j = generator.multinomial(scores, 0, nodes.length);
+                nodeAddress = nodes[j];
+                startTask(nodeAddress);
+                res[i] = nodeAddress;
+            }
+        } else {
+            for (uint i = 0; i < k; i++) {
+                (bytes32[] memory gpuIDs, uint[] memory idScores) = filterGPUID(vramLimit, 1);
+                uint index = generator.multinomial(
+                    idScores,
+                    0,
+                    idScores.length
+                );
+                bytes32 gpuID = gpuIDs[index];
+                (address[] memory nodes, uint[] memory scores) = filterNodesByGPUID(gpuID);
+                uint j = generator.multinomial(scores, 0, nodes.length);
+                nodeAddress = nodes[j];
+                startTask(nodeAddress);
+                res[i] = nodeAddress;
+            }
+        }
+
+        return res;
     }
 
     function selectNodesWithRoot(

--- a/contracts/Node.sol
+++ b/contracts/Node.sol
@@ -350,7 +350,7 @@ contract Node is Ownable {
     function filterGPUID(
         uint vramLimit,
         uint countLimit
-    ) public view returns (bytes32[] memory, uint[] memory) {
+    ) private view returns (bytes32[] memory, uint[] memory) {
         uint[] memory scores = new uint[](_availableGPUIDSet.length());
         bytes32[] memory ids = new bytes32[](_availableGPUIDSet.length());
         uint validCount = 0;
@@ -383,7 +383,7 @@ contract Node is Ownable {
         return (ids, scores);
     }
 
-    function filterNodesByGPUID(bytes32 gpuID) public view returns (address[] memory, uint[] memory) {
+    function filterNodesByGPUID(bytes32 gpuID) private view returns (address[] memory, uint[] memory) {
         uint length = _gpuIDNodesIndex[gpuID].length();
         require(length > 0, "No available node");
 
@@ -445,7 +445,7 @@ contract Node is Ownable {
     function selectNodesWithRoot(
         address root,
         uint k
-    ) public view returns (address[] memory) {
+    ) external view returns (address[] memory) {
         require(k > 0, "select nodes count cannot be zero");
         require(_availableNodes.length() >= k, "No available node");
         require(_availableNodes.contains(root), "root node should be available");

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -6,13 +6,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./Node.sol";
 import "./Hamming.sol";
-import "./Random.sol";
 import "./QOS.sol";
 import "./TaskQueue.sol";
 import "./NetworkStats.sol";
 
 contract Task is Ownable {
-    using Random for Random.Generator;
 
     uint private TASK_TYPE_SD = 0;
     uint private TASK_TYPE_LLM = 1;
@@ -54,8 +52,6 @@ contract Task is Ownable {
     uint256 private numSuccessTasks;
     uint256 private numAbortedTasks;
 
-    Random.Generator private generator;
-
     event TaskPending(
         uint256 taskId,
         uint256 taskType,
@@ -93,6 +89,7 @@ contract Task is Ownable {
         qos = qosInstance;
         taskQueue = taskQueueInstance;
         netStats = netStatsInstance;
+
         nextTaskId = 1;
         distanceThreshold = 5;
         timeout = 15 minutes;
@@ -147,7 +144,7 @@ contract Task is Ownable {
             abi.encodePacked(blockhash(block.number - 1), taskHash, dataHash)
         );
         try
-            this.randomSelectNodes(
+            node.randomSelectNodes(
                 3,
                 vramLimit,
                 taskType == TASK_TYPE_LLM,
@@ -210,53 +207,6 @@ contract Task is Ownable {
                 revert(reason);
             }
         }
-    }
-
-    function randomSelectNodes(
-        uint k,
-        uint vramLimit,
-        bool useSameGPU,
-        bytes32 seed
-    ) external returns (address[] memory) {
-        require(k > 0, "select nodes count cannot be zero");
-
-        generator.manualSeed(seed);
-        address nodeAddress;
-        address[] memory res = new address[](k);
-
-        if (useSameGPU) {
-            (bytes32[] memory gpuIDs, uint[] memory idScores) = node
-                .filterGPUID(vramLimit, k);
-            uint index = generator.multinomial(idScores, 0, idScores.length);
-            bytes32 gpuID = gpuIDs[index];
-            for (uint i = 0; i < k; i++) {
-                (address[] memory nodes, uint[] memory scores) = node
-                    .filterNodesByGPUID(gpuID);
-                uint j = generator.multinomial(scores, 0, nodes.length);
-                nodeAddress = nodes[j];
-                node.startTask(nodeAddress);
-                res[i] = nodeAddress;
-            }
-        } else {
-            for (uint i = 0; i < k; i++) {
-                (bytes32[] memory gpuIDs, uint[] memory idScores) = node
-                    .filterGPUID(vramLimit, 1);
-                uint index = generator.multinomial(
-                    idScores,
-                    0,
-                    idScores.length
-                );
-                bytes32 gpuID = gpuIDs[index];
-                (address[] memory nodes, uint[] memory scores) = node
-                    .filterNodesByGPUID(gpuID);
-                uint j = generator.multinomial(scores, 0, nodes.length);
-                nodeAddress = nodes[j];
-                node.startTask(nodeAddress);
-                res[i] = nodeAddress;
-            }
-        }
-
-        return res;
     }
 
     function nodeAvailableCallback(address root) external {
@@ -678,7 +628,7 @@ contract Task is Ownable {
         bytes memory resultB = tasks[taskId].results[roundB];
 
         if (taskType == TASK_TYPE_SD) {
-            return compareHamming(resultA, resultB, distanceThreshold);
+            return Hamming.compareHamming(resultA, resultB, distanceThreshold);
         } else if (taskType == TASK_TYPE_LLM) {
             return keccak256(resultA) == keccak256(resultB);
         } else {
@@ -744,23 +694,6 @@ contract Task is Ownable {
             taskId,
             tasks[taskId].resultDisclosedRounds[discloseIndex]
         );
-    }
-
-    function compareHamming(
-        bytes memory a,
-        bytes memory b,
-        uint threshold
-    ) internal pure returns (bool) {
-        if (a.length == b.length && a.length % 8 == 0) {
-            for (uint start = 0; start < a.length; start += 8) {
-                uint distance = Hamming.hamming(a, b, start, start + 8);
-                if (distance >= threshold) {
-                    return false;
-                }
-            }
-            return true;
-        }
-        return false;
     }
 
     function updateDistanceThreshold(uint threshold) public onlyOwner {

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -75,6 +75,7 @@ contract Task is Ownable {
     event TaskResultCommitmentsReady(uint256 indexed taskId);
     event TaskSuccess(uint256 indexed taskId, bytes result, address indexed resultNode);
     event TaskAborted(uint256 indexed taskId, string reason);
+    event TaskResultUploaded(uint256 indexed taskId);
 
     constructor(
         Node nodeInstance,
@@ -455,6 +456,7 @@ contract Task is Ownable {
 
         settleNodeByRound(taskId, round);
         tryDeleteTask(taskId);
+        emit TaskResultUploaded(taskId);
     }
 
     function reportTaskError(uint256 taskId, uint round) public {

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -72,9 +72,9 @@ contract Task is Ownable {
         bytes32 dataHash,
         uint round
     );
-    event TaskResultCommitmentsReady(uint256 taskId);
-    event TaskSuccess(uint256 taskId, bytes result, address indexed resultNode);
-    event TaskAborted(uint256 taskId, string reason);
+    event TaskResultCommitmentsReady(uint256 indexed taskId);
+    event TaskSuccess(uint256 indexed taskId, bytes result, address indexed resultNode);
+    event TaskAborted(uint256 indexed taskId, string reason);
 
     constructor(
         Node nodeInstance,

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -178,6 +178,9 @@ contract Task is Ownable {
             if (keccak256(bytes(reason)) == keccak256(bytes(target))) {
                 if (taskQueue.size() == taskQueue.getSizeLimit()) {
                     TaskInQueue memory task = taskQueue.removeCheapestTask();
+                    // stats task count in netstats
+                    netStats.taskStarted();
+                    netStats.taskFinished();
                     emit TaskAborted(task.id, "Task fee is too low");
                 }
                 emit TaskPending(
@@ -548,6 +551,9 @@ contract Task is Ownable {
                 cnxToken.transfer(task.creator, task.taskFee),
                 "Token transfer failed"
             );
+            // stats task count in netstats
+            netStats.taskStarted();
+            netStats.taskFinished();
             emit TaskAborted(taskId, "Task Cancelled");
         } else {
             revert("Task not exist");

--- a/contracts/Task.sol
+++ b/contracts/Task.sol
@@ -77,6 +77,10 @@ contract Task is Ownable {
     event TaskAborted(uint256 indexed taskId, string reason);
     event TaskResultUploaded(uint256 indexed taskId);
 
+    event TaskNodeSuccess(uint indexed taskId, address nodeAddress, uint fee);
+    event TaskNodeSlashed(uint indexed taskId, address nodeAddress);
+    event TaskNodeCancelled(uint indexed taskId, address nodeAddress);
+
     constructor(
         Node nodeInstance,
         IERC20 tokenInstance,
@@ -542,6 +546,7 @@ contract Task is Ownable {
                 if (nodeTasks[nodeAddress] != 0) {
                     nodeTasks[nodeAddress] = 0;
                     node.finishTask(nodeAddress);
+                    emit TaskNodeCancelled(taskId, nodeAddress);
                 }
             }
             delete tasks[taskId];
@@ -652,6 +657,7 @@ contract Task is Ownable {
             address nodeAddress = tasks[taskId].selectedNodes[round];
             nodeTasks[nodeAddress] = 0;
             node.finishTask(nodeAddress);
+            emit TaskNodeCancelled(taskId, nodeAddress);
         }
 
         numAbortedTasks++;
@@ -694,6 +700,7 @@ contract Task is Ownable {
         // Free the node
         nodeTasks[nodeAddress] = 0;
         node.finishTask(nodeAddress);
+        emit TaskNodeSuccess(taskId, nodeAddress, fee);
     }
 
     function settleNodeByDiscloseIndex(
@@ -726,6 +733,7 @@ contract Task is Ownable {
         // Free the node
         nodeTasks[nodeAddress] = 0;
         node.slash(nodeAddress);
+        emit TaskNodeSlashed(taskId, nodeAddress);
     }
 
     function punishNodeByDiscloseIndex(

--- a/test/TestTaskHeap.sol
+++ b/test/TestTaskHeap.sol
@@ -41,11 +41,11 @@ contract TestTaskHeap {
         }
         Assert.isFalse(maxHeap.include(7), "Wrong include");
 
-        TaskInQueue memory task;
-        task = maxHeap.remove(3);
-        Assert.equal(task.taskFee, 300, "Wrong remove task");
-        task = maxHeap.remove(4);
-        Assert.equal(task.taskFee, 400, "Wrong remove task");
+        TaskInQueue memory task1;
+        task1 = maxHeap.remove(3);
+        Assert.equal(task1.taskFee, 300, "Wrong remove task");
+        task1 = maxHeap.remove(4);
+        Assert.equal(task1.taskFee, 400, "Wrong remove task");
         
         Assert.isFalse(maxHeap.include(3), "Wrong include");
         Assert.isFalse(maxHeap.include(4), "Wrong include");
@@ -55,10 +55,10 @@ contract TestTaskHeap {
             maxHeap.pop();
         }
 
-        task = maxHeap.remove(1);
-        Assert.equal(task.taskFee, 100, "Wrong remove task");
-        task = maxHeap.remove(2);
-        Assert.equal(task.taskFee, 200, "Wrong remove task");
+        task1 = maxHeap.remove(1);
+        Assert.equal(task1.taskFee, 100, "Wrong remove task");
+        task1 = maxHeap.remove(2);
+        Assert.equal(task1.taskFee, 200, "Wrong remove task");
 
     }
 
@@ -92,11 +92,11 @@ contract TestTaskHeap {
         }
         Assert.isFalse(minHeap.include(7), "Wrong include");
 
-        TaskInQueue memory task;
-        task = minHeap.remove(3);
-        Assert.equal(task.taskFee, 400, "Wrong remove task");
-        task = minHeap.remove(4);
-        Assert.equal(task.taskFee, 300, "Wrong remove task");
+        TaskInQueue memory task1;
+        task1 = minHeap.remove(3);
+        Assert.equal(task1.taskFee, 400, "Wrong remove task");
+        task1 = minHeap.remove(4);
+        Assert.equal(task1.taskFee, 300, "Wrong remove task");
         
         Assert.isFalse(minHeap.include(3), "Wrong include");
         Assert.isFalse(minHeap.include(4), "Wrong include");
@@ -106,9 +106,9 @@ contract TestTaskHeap {
             minHeap.pop();
         }
 
-        task = minHeap.remove(1);
-        Assert.equal(task.taskFee, 600, "Wrong remove task");
-        task = minHeap.remove(2);
-        Assert.equal(task.taskFee, 500, "Wrong remove task");
+        task1 = minHeap.remove(1);
+        Assert.equal(task1.taskFee, 600, "Wrong remove task");
+        task1 = minHeap.remove(2);
+        Assert.equal(task1.taskFee, 500, "Wrong remove task");
     }
 }

--- a/test/task-node-events.spec.js
+++ b/test/task-node-events.spec.js
@@ -1,0 +1,346 @@
+const Node = artifacts.require("Node");
+const CrynuxToken = artifacts.require("CrynuxToken");
+const Task = artifacts.require("Task");
+const truffleAssert = require('truffle-assertions');
+const { time } = require("@openzeppelin/test-helpers")
+
+const { prepareTask, prepareNetwork, prepareUser, getCommitment} = require("./utils");
+
+contract("Task", (accounts) => {
+    it("should emit 3 TaskNodeSuccess when all nodes run correctly", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+
+        for(let i= 0; i < 3; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        for(let i = 0; i < 3; i++) {
+            await taskInstance.discloseTaskResult(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                result,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        await taskInstance.reportResultsUploaded(taskId, nodeRounds[accounts[2]], {from: accounts[2]});
+        
+        const events = await taskInstance.getPastEvents("TaskNodeSuccess", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(events.length, 3, "Wrong event count");
+        for (const event of events) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 5), event.args.nodeAddress);
+        }
+    });
+});
+
+contract("Task", (accounts) => {
+    it("should emit 2 TaskNodeSuccess and 1 TaskNodeSlashed when two nodes run correctly and a node cheats", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+        const fakeResult = "0x010203040506f7f8";
+
+        for(let i= 0; i < 2; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        {
+            const [commitment, nonce] = getCommitment(fakeResult);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[4]],
+                commitment,
+                nonce,
+                {from: accounts[4]}
+            );
+
+        }
+
+        for(let i = 0; i < 2; i++) {
+            await taskInstance.discloseTaskResult(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                result,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        {
+            await taskInstance.discloseTaskResult(
+                taskId,
+                nodeRounds[accounts[4]],
+                fakeResult,
+                {from: accounts[4]}
+            );
+        }
+
+        await taskInstance.reportResultsUploaded(taskId, nodeRounds[accounts[2]], {from: accounts[2]});
+        
+        const successEvents = await taskInstance.getPastEvents("TaskNodeSuccess", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(successEvents.length, 2, "Wrong event count");
+        for (const event of successEvents) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 4), event.args.nodeAddress);
+        }
+
+        const slashEvents = await taskInstance.getPastEvents("TaskNodeSlashed", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(slashEvents.length, 1, "Wrong event count");
+        assert.equal(slashEvents[0].args.taskId.toString(), taskId.toString(), "Wrong taskId");
+        assert.equal(slashEvents[0].args.nodeAddress, accounts[4], "Wrong taskId");
+    });
+});
+
+contract("Task", (accounts) => {
+    it("should emit 2 TaskNodeSuccess and 1 TaskNodeSlashed when two nodes run correctly and a node reports error", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+
+        for(let i= 0; i < 2; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        {
+            await taskInstance.reportTaskError(
+                taskId,
+                nodeRounds[accounts[4]],
+                {from: accounts[4]}
+            );
+        }
+
+        for(let i = 0; i < 2; i++) {
+            await taskInstance.discloseTaskResult(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                result,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        await taskInstance.reportResultsUploaded(taskId, nodeRounds[accounts[2]], {from: accounts[2]});
+        
+        const successEvents = await taskInstance.getPastEvents("TaskNodeSuccess", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(successEvents.length, 2, "Wrong event count");
+        for (const event of successEvents) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 4), event.args.nodeAddress);
+        }
+
+        const slashEvents = await taskInstance.getPastEvents("TaskNodeSlashed", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(slashEvents.length, 1, "Wrong event count");
+        assert.equal(slashEvents[0].args.taskId.toString(), taskId.toString(), "Wrong taskId");
+        assert.equal(slashEvents[0].args.nodeAddress, accounts[4], "Wrong taskId");
+    });
+});
+
+contract("Task", (accounts) => {
+    it("should emit 2 TaskNodeSuccess and 1 TaskNodeCancelled when two nodes disclose correctly and a node is timeout", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+
+        for(let i= 0; i < 3; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        for(let i = 0; i < 2; i++) {
+            await taskInstance.discloseTaskResult(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                result,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        await taskInstance.reportResultsUploaded(taskId, nodeRounds[accounts[2]], {from: accounts[2]});
+        
+        const successEvents = await taskInstance.getPastEvents("TaskNodeSuccess", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(successEvents.length, 2, "Wrong event count");
+        for (const event of successEvents) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 4), event.args.nodeAddress);
+        }
+
+        await time.increase(time.duration.hours(1));
+        await taskInstance.cancelTask(taskId, {from: accounts[4]});
+
+        const cancelEvents = await taskInstance.getPastEvents("TaskNodeCancelled", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(cancelEvents.length, 1, "Wrong event count");
+        assert.equal(cancelEvents[0].args.taskId.toString(), taskId.toString(), "Wrong taskId");
+        assert.equal(cancelEvents[0].args.nodeAddress, accounts[4], "Wrong taskId");
+    });
+});
+
+contract("Task", (accounts) => {
+    it("should emit 3 TaskNodeCancelled when two nodes submit result commitments correctly and a node is timeout", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+
+        for(let i= 0; i < 2; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        await time.increase(time.duration.hours(1));
+        await taskInstance.cancelTask(taskId, {from: accounts[4]});
+        
+        const successEvents = await taskInstance.getPastEvents("TaskNodeCancelled", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(successEvents.length, 3, "Wrong event count");
+        for (const event of successEvents) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 5), event.args.nodeAddress);
+        }
+    });
+});
+
+contract("Task", (accounts) => {
+    it("should emit 3 TaskNodeCancelled when one node disclose correctly and two nodes are timeout", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+
+        for(let i= 0; i < 3; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        await taskInstance.discloseTaskResult(
+            taskId,
+            nodeRounds[accounts[2]],
+            result,
+            {from: accounts[2]}
+        )
+
+        await time.increase(time.duration.hours(1));
+        await taskInstance.cancelTask(taskId, {from: accounts[4]});
+        
+        const events = await taskInstance.getPastEvents("TaskNodeCancelled", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(events.length, 3, "Wrong event count");
+        for (const event of events) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 5), event.args.nodeAddress);
+        }
+    });
+});
+
+contract("Task", (accounts) => {
+    it("should emit 3 TaskNodeSuccess when three nodes report task error", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+
+        for(let i= 0; i < 3; i++) {
+            await taskInstance.reportTaskError(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                {from: accounts[2 + i]}
+            );
+        }
+
+        const events = await taskInstance.getPastEvents("TaskNodeSuccess", {fromBlock: 0, toBlock: "latest"});
+        assert.equal(events.length, 3, "Wrong event count");
+        for (const event of events) {
+            assert.equal(event.args.taskId.toString(), taskId.toString(), "Wrong taskId");
+
+            assert.include(accounts.slice(2, 5), event.args.nodeAddress);
+        }
+    });
+});

--- a/test/task-result-uploaded.spec.js
+++ b/test/task-result-uploaded.spec.js
@@ -1,0 +1,46 @@
+const Node = artifacts.require("Node");
+const CrynuxToken = artifacts.require("CrynuxToken");
+const Task = artifacts.require("Task");
+const truffleAssert = require('truffle-assertions');
+
+const { prepareTask, prepareNetwork, prepareUser, getCommitment} = require("./utils");
+
+contract("Task", (accounts) => {
+    it("should emit TaskResultUploaded when task.reportResultsUploaded is called", async () => {
+        const taskInstance = await Task.deployed();
+        const cnxInstance = await CrynuxToken.deployed();
+        const nodeInstance = await Node.deployed();
+
+        await prepareNetwork(accounts, cnxInstance, nodeInstance);
+        await prepareUser(accounts[1], cnxInstance, taskInstance);
+
+        const [taskId, nodeRounds] = await prepareTask(accounts, cnxInstance, nodeInstance, taskInstance);
+
+        const result = "0x0102030405060708";
+
+        for(let i= 0; i < 3; i++) {
+            const [commitment, nonce] = getCommitment(result);
+            await taskInstance.submitTaskResultCommitment(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                commitment,
+                nonce,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        for(let i = 0; i < 3; i++) {
+            await taskInstance.discloseTaskResult(
+                taskId,
+                nodeRounds[accounts[2 + i]],
+                result,
+                {from: accounts[2 + i]}
+            );
+        }
+
+        const tx = await taskInstance.reportResultsUploaded(taskId, nodeRounds[accounts[2]], {from: accounts[2]});
+        truffleAssert.eventEmitted(tx, "TaskResultUploaded", (ev) => {
+            return ev.taskId.toString() === taskId.toString();
+        })
+    });
+});


### PR DESCRIPTION
- bug fix: index taskId of TaskResultCommitmentsReady, TaskSuccess, TaskAborted event
- statstic task count in netstats correctly when task is cancelled or remove from the task queue
- add event TaskResultUploaded, TaskNodeSuccess, TaskNodeSlashed and TaskNodeCancelled
- move randomSelectNodes method from task to node contract to reduce task contract bytecode size
