### PR TITLE
fea-fix: TaskCreation, randomseed return, parameters merkle related.

### DIFF
--- a/contracts/VSSTask.sol
+++ b/contracts/VSSTask.sol
@@ -125,6 +125,9 @@ contract VSSTask is Ownable {
     uint256 private nextSequence;
     address private relayAddress;
     uint256 private timeout;
+    mapping(bytes32 => bytes32) private merkleProofs;
+    mapping(bytes32 => bytes32) private merkleRoots;
+
 
     uint private distanceThreshold;
 
@@ -195,7 +198,7 @@ contract VSSTask is Ownable {
         uint requiredGPUVRAM,
         string calldata taskVersion,
         uint taskSize
-    ) public payable {
+    ) public payable returns (bytes32){
         if (taskType == TaskType.LLM || taskType == TaskType.SD_FT) {
             require(bytes(requiredGPU).length > 0, "GPU name is empty");
         }
@@ -261,6 +264,7 @@ contract VSSTask is Ownable {
                 revert(reason);
             }
         }
+        return taskInfo.samplingSeed;
     }
 
     function validateSingleTask(
@@ -463,6 +467,15 @@ contract VSSTask is Ownable {
         }
     }
 
+    function reportTaskParametersUploaded(bytes32 taskIDCommitment, bytes32 merkleProof) public {
+        checkStateTransitionAllowance(
+            taskIDCommitment,
+            TaskStateTransition.ReportTaskParametersUploaded
+        );
+        merkleProofs[taskIDCommitment] = merkleProof;
+        changeTaskState(taskIDCommitment, TaskStatus.ParametersUploaded);
+    }
+
     /* Interfaces for nodes */
 
     function reportTaskError(bytes32 taskIDCommitment, TaskError error) public {
@@ -524,13 +537,8 @@ contract VSSTask is Ownable {
 
     /* Interfaces for Relay */
 
-    function reportTaskParametersUploaded(bytes32 taskIDCommitment) public {
-        checkStateTransitionAllowance(
-            taskIDCommitment,
-            TaskStateTransition.ReportTaskParametersUploaded
-        );
-
-        changeTaskState(taskIDCommitment, TaskStatus.ParametersUploaded);
+    function updatedMerkleRoot(bytes32 taskIDCommitment, bytes32 merkleRoot) public {
+        merkleRoots[taskIDCommitment] = merkleRoot;
     }
 
     function reportTaskResultUploaded(bytes32 taskIDCommitment) public {


### PR DESCRIPTION
I have made some changes to the task creation process. 
I've noticed some differences in the design that make it challenging for me to write the test cases. 
Therefore, I have updated the return value of the createTask function and added storage for the uploaded parameters' Merkle values and their corresponding proofs.